### PR TITLE
allow setting a fixed day in the week for weekly restarts instead of …

### DIFF
--- a/conf/ServerAutoShutdown.conf.dist
+++ b/conf/ServerAutoShutdown.conf.dist
@@ -24,6 +24,15 @@ ServerAutoShutdown.Enabled = 0
 ServerAutoShutdown.EveryDays = 1
 
 #
+#    ServerAutoShutdown.Weekday
+#        Description: If set (0-6, where 0=Sunday, 1=Monday, ... 6=Saturday), the server will restart on this weekday at the configured time.
+#                     Overrides ServerAutoShutdown.EveryDays if set to a valid value.
+#        Default:     -1 (disabled)
+#
+
+ServerAutoShutdown.Weekday = 3
+
+#
 #    ServerAutoShutdown.Time
 #        Description: Time (in HH:MM:SS) - 24 hours format
 #        Default:     04:00:00

--- a/conf/ServerAutoShutdown.conf.dist
+++ b/conf/ServerAutoShutdown.conf.dist
@@ -30,7 +30,7 @@ ServerAutoShutdown.EveryDays = 1
 #        Default:     -1 (disabled)
 #
 
-ServerAutoShutdown.Weekday = 3
+ServerAutoShutdown.Weekday = -1
 
 #
 #    ServerAutoShutdown.Time


### PR DESCRIPTION
### Summary
Introduces a configuration option to schedule server restarts on a specific day of the week, providing an alternative to the existing "every X days" restart option.

### Changes
- Adds a new `ServerAutoShutdown.Weekday` configuration parameter to specify a fixed restart day (0=Sunday, ..., 6=Saturday).
- Implements logic to calculate the next restart time based on the configured weekday.
- Updates the fallback logic to prioritize weekday-based scheduling when both options are set.

### Benefits
- Enables precise weekly scheduling for server restarts.
- Provides greater flexibility for server administrators by allowing them to choose between weekday-based restarts or periodic restarts.
- closes #1 

### Notes
- The existing "restart every X days" option remains functional and serves as a fallback when the new weekday parameter is not configured.
- Includes validation to ensure incorrect configuration values do not cause unintended behavior.